### PR TITLE
Verify checksums

### DIFF
--- a/fetch_release.py
+++ b/fetch_release.py
@@ -69,7 +69,7 @@ def get_micromamba(version='latest'):
         buildplat = d["attrs"]["subdir"]
 
         url = d["download_url"]
-        sha256 = d["sha256"]
+        dsum = d["sha256"]
 
         dplat = d["attrs"]["subdir"]
 
@@ -86,6 +86,14 @@ def get_micromamba(version='latest'):
         dlloc = Path(f"micromamba-{version}-{build_number}-{dplat}{ext}")
         with open(dlloc, "wb") as f:
             f.write(r.content)
+
+        # verify the sha256
+        sha256 = hashlib.sha256()
+        with open(dlloc, "rb") as f:
+            sha256.update(f.read())
+        dlsum = sha256.hexdigest()
+        if dlsum != dsum:
+            raise Exception(f"checksum mismatch, expected {dsum} but was {dlsum}")
 
         # extract the file
         extract_dir = Path(f"micromamba-{version}-{build_number}-{dplat}")


### PR DESCRIPTION
Noticed this useful little project - only after implementing my own script for downloading and extracting the executable from anaconda.org... Much more convenient to have the single binary available for direct download, and also with the more familiar GitHub API. Thanks.

While "comparing notes", I noticed that you read out the sha256 of the package file from the anaconda response, but you never use it. (The sha256 you publish for the artifacts in the release are always the hash of the extracted micromamba binary.) Wouldn't it be good to verify the package file download using that sha256?