### PR TITLE
improve `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,8 @@ case "$ARCH" in
 esac
 
 case "$PLATFORM-$ARCH" in
-  linux-aarch64|linux-ppc64le|linux-64|osx-arm64|osx-64|win-64) ;;
+  linux-aarch64|linux-ppc64le|linux-64|osx-arm64|osx-64|win-64)
+      ;;  # pass
   *)
     echo "Failed to detect your OS" >&2
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -78,12 +78,24 @@ case "$INIT_YES" in
   y|Y|yes)
     case "`"${BIN_FOLDER}/micromamba" --version`" in
       1.*|0.*)
-        "${BIN_FOLDER}/micromamba" shell init -p "${PREFIX_LOCATION}"
+        shell_arg=-s
+        prefix_arg=-p
         ;;
       *)
-        "${BIN_FOLDER}/micromamba" shell init --root-prefix "${PREFIX_LOCATION}"
+        shell_arg=--shell
+        prefix_arg=--root-prefix
         ;;
     esac
+
+    SHELLS=
+    [ -e $HOME/.bashrc ] && SHELLS="$SHELLS bash"
+    [ -e "${XDG_CONFIG_HOME:-$HOME/.config}/fish" ] && SHELLS="$SHELLS fish"
+    [ -e "$HOME/.xonshrc" -o -e "${XDG_CONFIG_HOME:-$HOME/.config}/xonsh" ] && SHELLS="$SHELLS xonsh"
+    [ -e "${ZDOTDIR:-$HOME}/.zshrc" ] && SHELLS="$SHELLS zsh"
+
+    for shell in $SHELLS; do
+        "${BIN_FOLDER}/micromamba" shell init $shell_arg $shell $prefix_arg "$PREFIX_LOCATION"
+    done
 
     echo "Please restart your shell to activate micromamba or run the following:\n"
     echo "  source ~/.bashrc (or ~/.zshrc, ...)"

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ esac
 PREFIX_LOCATION="${PREFIX_LOCATION:-${HOME}/micromamba}"
 
 # Computing artifact location
-case "`uname`" in
+case "$(uname)" in
   Linux)
     PLATFORM="linux" ;;
   Darwin)
@@ -38,7 +38,7 @@ case "`uname`" in
     PLATFORM="win" ;;
 esac
 
-ARCH="`uname -m`"
+ARCH="$(uname -m)"
 case "$ARCH" in
   aarch64|ppc64le|arm64)
       ;;  # pass
@@ -78,7 +78,7 @@ chmod +x "${BIN_FOLDER}/micromamba"
 # Initializing shell
 case "$INIT_YES" in
   y|Y|yes)
-    case "`"${BIN_FOLDER}/micromamba" --version`" in
+    case $("${BIN_FOLDER}/micromamba" --version) in
       1.*|0.*)
         shell_arg=-s
         prefix_arg=-p

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -eu
 
@@ -47,7 +47,7 @@ case "$PLATFORM-$ARCH" in
     ;;
 esac
 
-if [[ "${VERSION:-}" == "" ]]; then
+if [ "${VERSION:-}" = "" ]; then
   RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-${PLATFORM}-${ARCH}"
 else
   RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/download/micromamba-${VERSION}/micromamba-${PLATFORM}-${ARCH}"
@@ -61,24 +61,28 @@ chmod +x "${BIN_FOLDER}/micromamba"
 
 
 # Initializing shell
-if [[ "$INIT_YES" == "" || "$INIT_YES" == "y" || "$INIT_YES" == "Y" || "$INIT_YES" == "yes" ]]; then
-  case "$("${BIN_FOLDER}/micromamba" --version)" in
-    1.*|0.*)
-      "${BIN_FOLDER}/micromamba" shell init -p "${PREFIXLOCATION}"
-      ;;
-    *)
-      "${BIN_FOLDER}/micromamba" shell init --root-prefix "${PREFIXLOCATION}"
-      ;;
-  esac
+case "$INIT_YES" in
+  y|Y|yes)
+    case "`"${BIN_FOLDER}/micromamba" --version`" in
+      1.*|0.*)
+        "${BIN_FOLDER}/micromamba" shell init -p "${PREFIXLOCATION}"
+        ;;
+      *)
+        "${BIN_FOLDER}/micromamba" shell init --root-prefix "${PREFIXLOCATION}"
+        ;;
+    esac
 
-  echo "Please restart your shell to activate micromamba or run the following:\n"
-  echo "  source ~/.bashrc (or ~/.zshrc, ...)"
-fi
+    echo "Please restart your shell to activate micromamba or run the following:\n"
+    echo "  source ~/.bashrc (or ~/.zshrc, ...)"
+    ;;
+esac
 
 
 # Initializing conda-forge
-if [[ "$CONDA_FORGE_YES" == "" || "$CONDA_FORGE_YES" == "y" || "$CONDA_FORGE_YES" == "Y" || "$CONDA_FORGE_YES" == "yes" ]]; then
-  "${BIN_FOLDER}/micromamba" config append channels conda-forge
-  "${BIN_FOLDER}/micromamba" config append channels nodefaults
-  "${BIN_FOLDER}/micromamba" config set channel_priority strict
-fi
+case "$CONDA_FORGE_YES" in
+  y|Y|yes)
+    "${BIN_FOLDER}/micromamba" config append channels conda-forge
+    "${BIN_FOLDER}/micromamba" config append channels nodefaults
+    "${BIN_FOLDER}/micromamba" config set channel_priority strict
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -23,32 +23,29 @@ INIT_YES="${INIT_YES:-yes}"
 CONDA_FORGE_YES="${CONDA_FORGE_YES:-no}"
 
 # Computing artifact location
-ARCH="$(uname -m)"
-OS="$(uname)"
+case "`uname`" in
+  Linux)
+    PLATFORM="linux" ;;
+  Darwin)
+    PLATFORM="osx" ;;
+  *NT*)
+    PLATFORM="win" ;;
+esac
 
-if [[ "$OS" == "Linux" ]]; then
-  PLATFORM="linux"
-  if [[ "$ARCH" == "aarch64" ]]; then
-    ARCH="aarch64"
-  elif [[ $ARCH == "ppc64le" ]]; then
-    ARCH="ppc64le"
-  else
-    ARCH="64"
-  fi    
-elif [[ "$OS" == "Darwin" ]]; then
-  PLATFORM="osx"
-  if [[ "$ARCH" == "arm64" ]]; then
-    ARCH="arm64"
-  else
-    ARCH="64"
-  fi
-elif [[ "$OS" =~ "NT" ]]; then
-  PLATFORM="win"
-  ARCH="64"
-else
-  echo "Failed to detect your OS" >&2
-  exit 1
-fi
+ARCH="`uname -m`"
+case "$ARCH" in
+  aarch64|ppc64le|arm64) ;;
+  *)
+    ARCH="64" ;;
+esac
+
+case "$PLATFORM-$ARCH" in
+  linux-aarch64|linux-ppc64le|linux-64|osx-arm64|osx-64|win-64) ;;
+  *)
+    echo "Failed to detect your OS" >&2
+    exit 1
+    ;;
+esac
 
 if [[ "${VERSION:-}" == "" ]]; then
   RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-${PLATFORM}-${ARCH}"

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,14 @@ fi
 
 # Downloading artifact
 mkdir -p "${BIN_FOLDER}"
-curl "${RELEASE_URL}" -o "${BIN_FOLDER}/micromamba" -fsSL --compressed ${CURL_OPTS:-}
+if hash curl >/dev/null 2>&1; then
+  curl "${RELEASE_URL}" -o "${BIN_FOLDER}/micromamba" -fsSL --compressed ${CURL_OPTS:-}
+elif hash wget >/dev/null 2>&1; then
+  wget ${WGET_OPTS:-} -qO "${BIN_FOLDER}/micromamba" "${RELEASE_URL}"
+else
+  echo "Neither curl nor wget was found" >&2
+  exit 1
+fi
 chmod +x "${BIN_FOLDER}/micromamba"
 
 

--- a/install.sh
+++ b/install.sh
@@ -2,25 +2,31 @@
 
 set -eu
 
-
 # Parsing arguments
 if [ -t 0 ] ; then
   printf "Micromamba binary folder? [~/.local/bin] "
   read BIN_FOLDER
-  printf "Prefix location? [~/micromamba] "
-  read PREFIXLOCATION
   printf "Init shell? [Y/n] "
   read INIT_YES
   printf "Configure conda-forge? [Y/n] "
   read CONDA_FORGE_YES
 fi
 
-
 # Fallbacks
 BIN_FOLDER="${BIN_FOLDER:-${HOME}/.local/bin}"
-PREFIXLOCATION="${PREFIXLOCATION:-${HOME}/micromamba}"
 INIT_YES="${INIT_YES:-yes}"
 CONDA_FORGE_YES="${CONDA_FORGE_YES:-no}"
+
+# Prefix location is relevant only if we want to call `micromamba shell init`
+case "$INIT_YES" in
+  y|Y|yes)
+    if [ -t 0 ]; then
+      printf "Prefix location? [~/micromamba] "
+      read PREFIX_LOCATION
+    fi
+    ;;
+esac
+PREFIX_LOCATION="${PREFIX_LOCATION:-${HOME}/micromamba}"
 
 # Computing artifact location
 case "`uname`" in
@@ -72,10 +78,10 @@ case "$INIT_YES" in
   y|Y|yes)
     case "`"${BIN_FOLDER}/micromamba" --version`" in
       1.*|0.*)
-        "${BIN_FOLDER}/micromamba" shell init -p "${PREFIXLOCATION}"
+        "${BIN_FOLDER}/micromamba" shell init -p "${PREFIX_LOCATION}"
         ;;
       *)
-        "${BIN_FOLDER}/micromamba" shell init --root-prefix "${PREFIXLOCATION}"
+        "${BIN_FOLDER}/micromamba" shell init --root-prefix "${PREFIX_LOCATION}"
         ;;
     esac
 

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,8 @@ esac
 
 ARCH="`uname -m`"
 case "$ARCH" in
-  aarch64|ppc64le|arm64) ;;
+  aarch64|ppc64le|arm64)
+      ;;  # pass
   *)
     ARCH="64" ;;
 esac


### PR DESCRIPTION
This PR aims to make the install script support non-interactive installs, and support systems where common tools such as Bash may be unavailable (this may be the case with size-optimised containers, for example):

- Make it work in most shells, not just Bash.
- Simplify OS/ARCH detection.
- Make it use wget if curl is not available (some Linux distros install wget by default, but not curl).
- Allow `RUN_SHELL_INIT`, `PREFIX_LOCATION`, `DEFAULT_PREFIX_LOCATION` and `BIN_FOLDER` to be set before the script is run to facilitate non-interactive installation
- Initialise all available supported shells, not just the one calling the script

The script may be simplified when the XDG support becomes available, as there will be no need to ask for an installation prefix, as the paths of the `envs` and `pkgs` directories can be inferred from the `XDG_*` variables or their defaults. BTW, I see that https://github.com/mamba-org/mamba/issues/1787 is closed, but it looks like `$XDG_DATA_HOME` and `$XDG_CACHE_HOME` are not supported yet, am I right?

(My answers may be delayed for the next week or so due to holidays.)