### PR TITLE
Fix 404 error in install.sh if ${VERSION} is used 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ esac
 if [ "${VERSION:-}" = "" ]; then
   RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-${PLATFORM}-${ARCH}"
 else
-  RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/download/micromamba-${VERSION}/micromamba-${PLATFORM}-${ARCH}"
+  RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${VERSION}/micromamba-${PLATFORM}-${ARCH}"
 fi
 
 


### PR DESCRIPTION
The script offers the option to use the ${VERSION} env var to download a specific version rather than latest but it uses a wrong URL and I get a 404 error 

replacing download/micromamba-${VERSION} with 
download/${VERSION}