### PR TITLE
Set CONDA_FORGE_YES=yes by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ fi
 # Fallbacks
 BIN_FOLDER="${BIN_FOLDER:-${HOME}/.local/bin}"
 INIT_YES="${INIT_YES:-yes}"
-CONDA_FORGE_YES="${CONDA_FORGE_YES:-no}"
+CONDA_FORGE_YES="${CONDA_FORGE_YES:-yes}"
 
 # Prefix location is relevant only if we want to call `micromamba shell init`
 case "$INIT_YES" in


### PR DESCRIPTION
Currently in the install.sh script will ask the user if they would like to configure conda-forge:
https://github.com/mamba-org/micromamba-releases/blob/946ea168f610f3d8f7cdb25c12561ba286a59d75/install.sh#L25-L26
The script makes it seem like "Y" will be selected by default if the user enters nothing. However, later on in the script `CONDA_FORGE_YES` is set to "no" by default:
https://github.com/mamba-org/micromamba-releases/blob/946ea168f610f3d8f7cdb25c12561ba286a59d75/install.sh#L32

This PR changes line 32 so that `CONDA_FORGE_YES` is set to "yes" by default, which is what the user-facing prompt suggests.