### PR TITLE
Fix non-latest version URL on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,9 @@
 # check if VERSION env variable is set, otherwise use "latest"
-$VERSION = if ($null -eq $Env:VERSION) { "latest" } else { $Env:VERSION }
-
-$RELEASE_URL="https://github.com/mamba-org/micromamba-releases/releases/$VERSION/download/micromamba-win-64"
+$RELEASE_URL = if ($null -eq $Env:VERSION) {
+    "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64"
+} else {
+    "https://github.com/mamba-org/micromamba-releases/releases/download/$Env:VERSION/micromamba-win-64"
+}
 
 Write-Output "Downloading micromamba from $RELEASE_URL"
 curl.exe -L -o micromamba.exe $RELEASE_URL


### PR DESCRIPTION
Latest download URL is structured differently than version download URL.

There was a similar fix for the Linux installer https://github.com/mamba-org/micromamba-releases/pull/51

### Reproduce the bug

```powershell
$Env:VERSION = "1.5.10-0"
Invoke-Expression ((Invoke-WebRequest -Uri https://micro.mamba.pm/install.ps1).Content)
```

Doesn't install a working micromamba.exe

### Test the bugfix

```powershell
$Env:VERSION = "1.5.10-0"
Invoke-Expression ((Invoke-WebRequest -Uri https://raw.githubusercontent.com/truh/micromamba-releases/refs/heads/fix-release-url/install.ps1).Content)
```