### PR TITLE
Add `-AcceptDefaults` Switch to Enable Noninteractive Default Initialization

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,19 +1,15 @@
 <#
 .SYNOPSIS
-    Install micromamba on Windows with optional non-interactive default initialization.
+    Install micromamba on Windows with non-interactive default initialization when running without user interaction.
 
 .DESCRIPTION
     This script downloads and installs micromamba and adds it to your PATH.
     It supports both interactive and non-interactive initialization.
     If run interactively, it will prompt you whether to initialize micromamba
-    and allow you to specify a custom prefix. With the -AcceptDefaults switch,
-    it bypasses the prompts and automatically uses the default prefix 
+    and allow you to specify a custom prefix. When running non-interactively,
+    the script bypasses the prompts and automatically uses the default prefix
     ($Env:UserProfile\micromamba).
 #>
-
-param(
-    [switch]$AcceptDefaults
-)
 
 # check if VERSION env variable is set, otherwise use "latest"
 $RELEASE_URL = if ($null -eq $Env:VERSION) {
@@ -41,8 +37,8 @@ if ($PATH -notlike "*$Env:LocalAppData\micromamba*") {
     Write-Output "$MAMBA_INSTALL_PATH is already in PATH`n"
 }
 
-if ($null -eq $Host.UI.RawUI -or $AcceptDefaults) {
-    Write-Output "`nNon-interactive session or AcceptDefaults flag provided, initializing micromamba to $Env:UserProfile\micromamba`n"
+if ( ([Environment]::GetCommandLineArgs() -contains '-NonInteractive') -or [System.Console]::IsOutputRedirected -or (-not [Environment]::UserInteractive) ) {
+    Write-Output "`nNot an interactive session, initializing micromamba to $Env:UserProfile\micromamba`n"
     & $MAMBA_INSTALL_PATH shell init -s powershell -p $Env:UserProfile\micromamba
 } else {
     $choice = Read-Host "Do you want to initialize micromamba for the shell activate command? (Y/n)"
@@ -51,8 +47,7 @@ if ($null -eq $Host.UI.RawUI -or $AcceptDefaults) {
         if ($prefix -eq "") {
             $prefix = "$Env:UserProfile\micromamba"
         }
-
-        Write-Output "Initializing micromamba in  $prefix"
+        Write-Output "Initializing micromamba in $prefix"
         $MAMBA_INSTALL_PATH = Join-Path -Path $Env:LocalAppData -ChildPath micromamba\micromamba.exe
         Write-Output $MAMBA_INSTALL_PATH
         & $MAMBA_INSTALL_PATH shell init -s powershell -p $prefix

--- a/install.ps1
+++ b/install.ps1
@@ -1,3 +1,20 @@
+<#
+.SYNOPSIS
+    Install micromamba on Windows with optional non-interactive default initialization.
+
+.DESCRIPTION
+    This script downloads and installs micromamba and adds it to your PATH.
+    It supports both interactive and non-interactive initialization.
+    If run interactively, it will prompt you whether to initialize micromamba
+    and allow you to specify a custom prefix. With the -AcceptDefaults switch,
+    it bypasses the prompts and automatically uses the default prefix 
+    ($Env:UserProfile\micromamba).
+#>
+
+param(
+    [switch]$AcceptDefaults
+)
+
 # check if VERSION env variable is set, otherwise use "latest"
 $RELEASE_URL = if ($null -eq $Env:VERSION) {
     "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64"
@@ -24,23 +41,22 @@ if ($PATH -notlike "*$Env:LocalAppData\micromamba*") {
     Write-Output "$MAMBA_INSTALL_PATH is already in PATH`n"
 }
 
-# check if this is an interactive session
-if ($null -eq $Host.UI.RawUI) {
-    Write-Output "`nNot an interactive session, initializing micromamba to $Env:UserProfile\micromamba`n"
+if ($null -eq $Host.UI.RawUI -or $AcceptDefaults) {
+    Write-Output "`nNon-interactive session or AcceptDefaults flag provided, initializing micromamba to $Env:UserProfile\micromamba`n"
     & $MAMBA_INSTALL_PATH shell init -s powershell -p $Env:UserProfile\micromamba
-}
-
-$choice = Read-Host "Do you want to initialize micromamba for the shell activate command? (Y/n)"
-if ($choice -eq "y" -or $choice -eq "Y" -or $choice -eq "") {
-    $prefix = Read-Host "Enter the path to the micromamba prefix (default: $Env:UserProfile\micromamba)"
-    if ($prefix -eq "") {
-        $prefix = "$Env:UserProfile\micromamba"
-    }
-
-    Write-Output "Initializing micromamba in  $prefix"
-    $MAMBA_INSTALL_PATH = Join-Path -Path $Env:LocalAppData -ChildPath micromamba\micromamba.exe
-    Write-Output $MAMBA_INSTALL_PATH
-    & $MAMBA_INSTALL_PATH shell init -s powershell -p $prefix
 } else {
-    Write-Output "`nYou can always initialize powershell or cmd.exe with micromamba by running `nmicromamba shell init -s powershell -p $Env:UserProfile\micromamba`n"
+    $choice = Read-Host "Do you want to initialize micromamba for the shell activate command? (Y/n)"
+    if ($choice -eq "y" -or $choice -eq "Y" -or $choice -eq "") {
+        $prefix = Read-Host "Enter the path to the micromamba prefix (default: $Env:UserProfile\micromamba)"
+        if ($prefix -eq "") {
+            $prefix = "$Env:UserProfile\micromamba"
+        }
+
+        Write-Output "Initializing micromamba in  $prefix"
+        $MAMBA_INSTALL_PATH = Join-Path -Path $Env:LocalAppData -ChildPath micromamba\micromamba.exe
+        Write-Output $MAMBA_INSTALL_PATH
+        & $MAMBA_INSTALL_PATH shell init -s powershell -p $prefix
+    } else {
+        Write-Output "`nYou can always initialize powershell or cmd.exe with micromamba by running `nmicromamba shell init -s powershell -p $Env:UserProfile\micromamba`n"
+    }
 }


### PR DESCRIPTION
This PR updates the Windows micromamba installer script to support optional noninteractive default initialization. Previously, the script would attempt to prompt the user for input (via `Read-Host`) regardless of the session type, which causes errors in noninteractive mode because prompt functionality is not available. 

With this update:
- A new switch parameter `-AcceptDefaults` is introduced.
- When running in noninteractive mode (i.e. when `$Host.UI.RawUI` is `$null`) or if the `-AcceptDefaults` flag is provided, the script bypasses all interactive prompts and automatically initializes micromamba with the default prefix (`$Env:UserProfile\micromamba`).
- If the script is run interactively without the flag, it behaves as before, prompting the user for initialization and allowing a custom prefix.

**Note:**  
Due to the inherent limitations of noninteractive mode in PowerShell, any calls to `Read-Host` will fail. This update ensures that in such environments, the default behavior is enforced to avoid errors. Future improvements could further refine interactive detection and behavior.

Feel free to review and provide feedback.