### PR TITLE
Fix calculation of sha256 sum for archives (fixes #37)

### DIFF
--- a/fetch_release.py
+++ b/fetch_release.py
@@ -134,7 +134,7 @@ def get_micromamba(version, use_default_version):
 
         # compute the sha256
         sha256 = hashlib.sha256()
-        with open(outdir / f"micromamba-{dplat}", "rb") as f:
+        with open(outdir / f"micromamba-{dplat}{ext}", "rb") as f:
             sha256.update(f.read())
 
         with open(outdir / f"micromamba-{dplat}{ext}.sha256", "w") as f:


### PR DESCRIPTION
Sum over the actual archive, not the executable.